### PR TITLE
Fixes to dev-pi stability

### DIFF
--- a/devpi-server/Dockerfile
+++ b/devpi-server/Dockerfile
@@ -31,12 +31,14 @@ RUN set -x \
 	&& useradd --no-log-init -r -u $PUID -g $PGID devpi
 
 # copy in sensible defaults for devpi
-COPY entrypoint.sh entrypoint-functions.sh healthcheck.sh /usr/local/bin/
+COPY requirements.txt entrypoint.sh entrypoint-functions.sh healthcheck.sh /usr/local/bin/
 
 # install unifi dependencies
 RUN set -x \
     && fetchDeps=' \
         sudo \
+        git \
+        procps \
     ' \
     && apt-get update \
     && apt-get install -y --no-install-recommends $fetchDeps \
@@ -46,7 +48,7 @@ RUN set -x \
 # Install DevPi
 WORKDIR ${DEVPISERVER_SERVERDIR}
 RUN sudo su - devpi \
-    && pip install -U devpi-server devpi-client devpi-web
+    && pip install -r /usr/local/bin/requirements.txt
 
 EXPOSE 3141
 VOLUME ["$DEVPISERVER_SERVERDIR"]

--- a/devpi-server/entrypoint.sh
+++ b/devpi-server/entrypoint.sh
@@ -9,8 +9,6 @@ IFS=$'\n\t'
 SCRIPT_VERSION="1.0"
 # Last updated date: 2023-12-28
 
-set -Eeuo pipefail
-
 if [ "${DEBUG}" == 'true' ]; then
     set -x
 fi
@@ -57,3 +55,20 @@ if [ "$initialize" == "yes" ]; then
     echo -n "$DEVPI_ROOT_PASSWORD" > "$DEVPISERVER_SERVERDIR/.root_password"
     devpi logoff
 fi
+
+echo "ENTRYPOINT: Watching devpi-server"
+PID=$(pgrep devpi-server)
+
+if [ -z "$PID" ]; then
+    echo "ENTRYPOINT: Could not determine PID of devpi-server!"
+    exit 1
+fi
+
+set +e
+
+while : ; do
+    kill -0 "$PID" > /dev/null 2>&1 || break
+    sleep 2s
+done
+
+echo "ENTRYPOINT: devpi-server died, exiting..."

--- a/devpi-server/requirements.txt
+++ b/devpi-server/requirements.txt
@@ -1,0 +1,12 @@
+# Main server and web views
+devpi-server==6.3.1
+devpi-client==5.2.3
+devpi-web==4.0.8
+
+# Web extensions
+devpi-findlinks==2.0.1
+devpi-lockdown==2.0.0
+devpi-json-info==0.1.3
+
+# Tools
+devpi-cleaner==0.3.0


### PR DESCRIPTION
@mrossco-bssprx 

I borrowed some code from another repo and got this one working.

1. Moved pip dependencies to a requirements.txt file for ease
2. Added git and procps to apt-get package installation
3. The new code in entrypoint.sh handles monitoring the dev-pi process a little differently and seems to be more stable.